### PR TITLE
Improve missing app handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ Bugs can be reported [here](https://github.com/D4rK7355608/com.d4rk.qrcodescanne
 - QR Codes are not recommended for use with confidential/secret information, as they can be easily decoded by anyone with a smartphone.
 - D4rK QR & Bar Code Scanner Plus uses the ZXing library, which is a popular and open-source library for decoding QR codes. It is available under the Apache License 2.0.
 
+Some QR code types (for example contact cards, OTP or Bitcoin URIs) rely on other applications. If the scanner shows "No app found for this action" please install a compatible contacts, authenticator or wallet app.
+
+The "Scan image" option may not work on some Android 11 Go devices due to system limitations.
+
 ## 💬 Feedback!
 We are constantly updating and improving QR & Bar Code Scanner Plus to give you the best possible experience. If you have any suggested features or improvements, please leave a review. In case something is not working correctly please let me know. When posting a low rating please describe what is wrong to give the possibility to fix that issue.
 

--- a/app/src/main/java/com/d4rk/qrcodescanner/plus/feature/barcode/BarcodeActivity.kt
+++ b/app/src/main/java/com/d4rk/qrcodescanner/plus/feature/barcode/BarcodeActivity.kt
@@ -727,13 +727,16 @@ class BarcodeActivity : BaseActivity(), DeleteConfirmationDialogFragment.Listene
         startActivityIfExists(intent)
     }
     private fun startActivityIfExists(intent: Intent) {
-        intent.apply {
-            flags = flags or Intent.FLAG_ACTIVITY_NEW_TASK
-        }
-        if (intent.resolveActivity(packageManager) != null) {
-            startActivity(intent)
-        } else {
-            snackBar(R.string.snack_no_app_found)
+        intent.flags = intent.flags or Intent.FLAG_ACTIVITY_NEW_TASK
+        lifecycleScope.launch {
+            val exists = withContext(Dispatchers.Default) {
+                intent.resolveActivity(packageManager) != null
+            }
+            if (exists) {
+                startActivity(intent)
+            } else {
+                snackBar(R.string.snack_no_app_found)
+            }
         }
     }
     private fun isAppInstalled(appPackage: String?): Boolean {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -247,7 +247,7 @@
     <string name="snack_copied_to_clipboard">Copied to clipboard! 📋</string>
     <string name="snack_saved_to_downloads">Saved to Downloads!</string>
     <string name="snack_saved_to_gallery">Saved to Gallery</string>
-    <string name="snack_no_app_found">No app found for this action</string>
+    <string name="snack_no_app_found">No app found for this action. Please install a compatible app.</string>
     <string name="snack_feedback">Thanks for rating us! ❤️</string>
     <string name="snack_support">Would you like to support our app? ❤️</string>
     <string name="tooltip_agree">Accept the terms and conditions.</string>


### PR DESCRIPTION
## Summary
- clarify README with note about required external apps and device limitations
- show more helpful snack bar when no app is available
- check for external activity in a coroutine

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68497ea60370832db4d67528c79e841e