### PR TITLE
Fix lint failures

### DIFF
--- a/app/src/main/java/com/d4rk/qrcodescanner/plus/ui/dialogs/EditBarcodeNameDialogFragment.kt
+++ b/app/src/main/java/com/d4rk/qrcodescanner/plus/ui/dialogs/EditBarcodeNameDialogFragment.kt
@@ -50,7 +50,6 @@ class EditBarcodeNameDialogFragment : DialogFragment() {
             requestFocus()
         }
         val manager = requireContext().getSystemService(Activity.INPUT_METHOD_SERVICE) as? InputMethodManager
-        @Suppress("DEPRECATION")
-        manager?.toggleSoftInput(InputMethodManager.HIDE_IMPLICIT_ONLY, 0)
+        manager?.showSoftInput(editText, InputMethodManager.SHOW_IMPLICIT)
     }
 }

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -167,7 +167,7 @@
     <string name="decrease_brightness">Намаляване на яркостта</string>
     <string name="unable_to_generate_password">Неуспешно генериране на парола</string>
     <string name="counter">Брояч: %s</string>
-    <string name="timer_left">%s:%s остават</string>
+    <string name="timer_left">%1$s:%2$s остават</string>
     <string name="refresh">Опресняване</string>
     <string name="youtube_url">URL адрес на Youtube</string>
     <string name="share_subject">Опитайте го сега!!!</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -166,7 +166,7 @@
     <string name="decrease_brightness">Helligkeit verringern</string>
     <string name="unable_to_generate_password">Kennwort kann nicht generiert werden</string>
     <string name="counter">Zähler: %s</string>
-    <string name="timer_left">%s:%s übrig</string>
+    <string name="timer_left">%1$s:%2$s übrig</string>
     <string name="refresh">Aktualisieren</string>
     <string name="youtube_url">Youtube-URL</string>
     <string name="share_subject">Jetzt ausprobieren!!!</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -167,7 +167,7 @@
     <string name="decrease_brightness">Disminuir brillo</string>
     <string name="unable_to_generate_password">No se puede generar la contraseña</string>
     <string name="counter">Contador: %s</string>
-    <string name="timer_left">%s:%s restante</string>
+    <string name="timer_left">%1$s:%2$s restante</string>
     <string name="refresh">Actualizar</string>
     <string name="youtube_url">URL de YouTube</string>
     <string name="share_subject">¡Pruébalo ahora!</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -166,7 +166,7 @@
     <string name="decrease_brightness">Diminuer la luminosité</string>
     <string name="unable_to_generate_password">Impossible de générer le mot de passe</string>
     <string name="counter">Compteur : %s</string>
-    <string name="timer_left">Temps restant : %s:%s</string>
+    <string name="timer_left">Temps restant : %1$s:%2$s</string>
     <string name="refresh">Actualiser</string>
     <string name="youtube_url">URL YouTube</string>
     <string name="share_subject">Essayez-le dès maintenant!!!</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -167,7 +167,7 @@
     <string name="decrease_brightness">चमकदारता कम करें</string>
     <string name="unable_to_generate_password">पासवर्ड बनाने में असमर्थ</string>
     <string name="counter">गिनती: %s</string>
-    <string name="timer_left">%s:%s बचे हुए</string>
+    <string name="timer_left">%1$s:%2$s बचे हुए</string>
     <string name="refresh">ताजगी करें</string>
     <string name="youtube_url">Youtube URL</string>
     <string name="share_subject">अभी आजमाएं!!!</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -166,7 +166,7 @@
     <string name="decrease_brightness">Fényerő csökkentése</string>
     <string name="unable_to_generate_password">Nem sikerült jelszót létrehozni</string>
     <string name="counter">Számláló: %s</string>
-    <string name="timer_left">%s:%s hátralévő idő</string>
+    <string name="timer_left">%1$s:%2$s hátralévő idő</string>
     <string name="refresh">Frissítés</string>
     <string name="youtube_url">YouTube URL</string>
     <string name="share_subject">Próbáld ki most!!!</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -167,7 +167,7 @@
     <string name="decrease_brightness">Kurangi kecerahan</string>
     <string name="unable_to_generate_password">Tidak dapat membuat kata sandi</string>
     <string name="counter">Penghitung: %s</string>
-    <string name="timer_left">%s:%s tersisa</string>
+    <string name="timer_left">%1$s:%2$s tersisa</string>
     <string name="refresh">Segarkan</string>
     <string name="youtube_url">URL Youtube</string>
     <string name="share_subject">Coba sekarang!!!</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -167,7 +167,7 @@
     <string name="decrease_brightness">Diminuisci luminosità</string>
     <string name="unable_to_generate_password">Impossibile generare password</string>
     <string name="counter">Contatore: %s</string>
-    <string name="timer_left">%s:%s rimanenti</string>
+    <string name="timer_left">%1$s:%2$s rimanenti</string>
     <string name="refresh">Aggiorna</string>
     <string name="youtube_url">URL di YouTube</string>
     <string name="share_subject">Provalo adesso!!!</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -166,7 +166,7 @@
     <string name="decrease_brightness">明るさを下げる</string>
     <string name="unable_to_generate_password">パスワードを生成できません</string>
     <string name="counter">カウンター: %s</string>
-    <string name="timer_left">%s:%s 残り</string>
+    <string name="timer_left">%1$s:%2$s 残り</string>
     <string name="refresh">更新</string>
     <string name="youtube_url">YouTube URL</string>
     <string name="share_subject">今すぐ試してみてください！</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -166,7 +166,7 @@
     <string name="decrease_brightness">Zmniejsz jasność</string>
     <string name="unable_to_generate_password">Nie można wygenerować hasła</string>
     <string name="counter">Licznik: %s</string>
-    <string name="timer_left">%s:%s pozostało</string>
+    <string name="timer_left">%1$s:%2$s pozostało</string>
     <string name="refresh">Odśwież</string>
     <string name="youtube_url">Adres URL w YouTube</string>
     <string name="share_subject">Spróbuj teraz!!!</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -167,7 +167,7 @@
     <string name="decrease_brightness">Reduce luminozitatea</string>
     <string name="unable_to_generate_password">Imposibil de generat parolă</string>
     <string name="counter">Contor: %s</string>
-    <string name="timer_left">%s:%s rămase</string>
+    <string name="timer_left">%1$s:%2$s rămase</string>
     <string name="refresh">Reîmprospătează</string>
     <string name="youtube_url">URL Youtube</string>
     <string name="share_subject">Încearcă acum!!!</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -167,7 +167,7 @@
     <string name="decrease_brightness">Уменьшить яркость</string>
     <string name="unable_to_generate_password">Невозможно сгенерировать пароль</string>
     <string name="counter">Счетчик: %s</string>
-    <string name="timer_left">%s:%s осталось</string>
+    <string name="timer_left">%1$s:%2$s осталось</string>
     <string name="refresh">Обновить</string>
     <string name="youtube_url">Ссылка на YouTube</string>
     <string name="share_subject">Попробуйте сейчас!!!</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -166,7 +166,7 @@
     <string name="decrease_brightness">Minska ljusstyrkan</string>
     <string name="unable_to_generate_password">Kan inte generera lösenord</string>
     <string name="counter">Räknare: %s</string>
-    <string name="timer_left">%s:%s kvar</string>
+    <string name="timer_left">%1$s:%2$s kvar</string>
     <string name="refresh">Uppdatera</string>
     <string name="youtube_url">Youtube URL</string>
     <string name="share_subject">Prova nu!!!</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -167,7 +167,7 @@
     <string name="decrease_brightness">Parlaklığı azalt</string>
     <string name="unable_to_generate_password">Şifre oluşturulamadı</string>
     <string name="counter">Sayıcı: %s</string>
-    <string name="timer_left">%s:%s kaldı</string>
+    <string name="timer_left">%1$s:%2$s kaldı</string>
     <string name="refresh">Yenile</string>
     <string name="youtube_url">Youtube URL\'si</string>
     <string name="share_subject">Hemen deneyin!!!</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -166,7 +166,7 @@
     <string name="decrease_brightness">Зменшити яскравість</string>
     <string name="unable_to_generate_password">Неможливо створити пароль</string>
     <string name="counter">Лічильник: %s</string>
-    <string name="timer_left">%s:%s залишилося</string>
+    <string name="timer_left">%1$s:%2$s залишилося</string>
     <string name="refresh">Оновити</string>
     <string name="youtube_url">URL-адреса YouTube</string>
     <string name="share_subject">Спробуйте зараз!!!</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -166,7 +166,7 @@
     <string name="decrease_brightness">Decrease brightness</string>
     <string name="unable_to_generate_password">Unable to generate password</string>
     <string name="counter">Counter: %s</string>
-    <string name="timer_left">%s:%s left</string>
+    <string name="timer_left">%1$s:%2$s left</string>
     <string name="refresh">Refresh</string>
     <string name="youtube_url">Youtube URL</string>
     <string name="share_subject">Try it now!!!</string>


### PR DESCRIPTION
## Summary
- fix invocation of InputMethodManager to show keyboard
- correct positional formatting for `timer_left` across locales

## Testing
- `./gradlew lintDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68766e671cc8832d94573f62956c6e5d